### PR TITLE
feat(blog): add article table of contents

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,8 @@ import tailwindcss from "@tailwindcss/vite";
 import { remarkSpotifyEmbed } from "./src/lib/remark-spotify-embed.ts";
 import remarkImageCaption from "./src/lib/remark-image-caption.ts";
 
+const astroCommand = globalThis.process?.argv.includes("dev") ? "dev" : "build";
+const viteCacheDir = `node_modules/.vite/${astroCommand}`;
 
 export default defineConfig({
   site: "https://haeward.com",
@@ -12,6 +14,7 @@ export default defineConfig({
   integrations: [sitemap(), mdx()],
 
   vite: {
+    cacheDir: viteCacheDir,
     plugins: [tailwindcss()],
   },
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint": "^10.0.0",
     "eslint-plugin-astro": "^1.0.0",
     "sharp": "^0.34.0",
-    "vite": "8.0.0"
+    "vite": "7.3.1"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 0.5.19(tailwindcss@4.2.1)
       '@tailwindcss/vite':
         specifier: ^4.0.0
-        version: 4.2.1(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.2))
+        version: 4.2.1(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))
       astro:
         specifier: ^6.0.0
         version: 6.0.4(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -82,8 +82,8 @@ importers:
         specifier: ^0.34.0
         version: 0.34.5
       vite:
-        specifier: 8.0.0
-        version: 8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.2)
+        specifier: 7.3.1
+        version: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)
 
 packages:
 
@@ -188,20 +188,8 @@ packages:
   '@emmetio/stream-reader@2.2.0':
     resolution: {integrity: sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==}
 
-  '@emnapi/core@1.9.0':
-    resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
-
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
-
-  '@emnapi/wasi-threads@1.2.0':
-    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
-
-  '@esbuild/aix-ppc64@0.27.3':
-    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
 
   '@esbuild/aix-ppc64@0.27.4':
     resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
@@ -209,22 +197,10 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.3':
-    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.27.4':
     resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.27.3':
-    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.4':
@@ -233,34 +209,16 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.3':
-    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.27.4':
     resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.3':
-    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.27.4':
     resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.3':
-    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.4':
@@ -269,22 +227,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.3':
-    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.27.4':
     resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.3':
-    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.4':
@@ -293,22 +239,10 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.3':
-    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.27.4':
     resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.3':
-    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.4':
@@ -317,22 +251,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.3':
-    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.27.4':
     resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.3':
-    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.4':
@@ -341,22 +263,10 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.3':
-    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.27.4':
     resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.3':
-    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.4':
@@ -365,22 +275,10 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.3':
-    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.27.4':
     resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
     engines: {node: '>=18'}
     cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.3':
-    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.4':
@@ -389,34 +287,16 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.3':
-    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.27.4':
     resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.3':
-    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
   '@esbuild/netbsd-arm64@0.27.4':
     resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.27.3':
-    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.4':
@@ -425,22 +305,10 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.3':
-    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
   '@esbuild/openbsd-arm64@0.27.4':
     resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.27.3':
-    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.4':
@@ -449,23 +317,11 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.3':
-    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@esbuild/openharmony-arm64@0.27.4':
     resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
-
-  '@esbuild/sunos-x64@0.27.3':
-    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.4':
     resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
@@ -473,34 +329,16 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.3':
-    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
   '@esbuild/win32-arm64@0.27.4':
     resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.3':
-    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.27.4':
     resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.3':
-    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.4':
@@ -743,9 +581,6 @@ packages:
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
-  '@napi-rs/wasm-runtime@1.1.1':
-    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
-
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -761,114 +596,9 @@ packages:
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
-  '@oxc-project/runtime@0.115.0':
-    resolution: {integrity: sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-
-  '@oxc-project/types@0.115.0':
-    resolution: {integrity: sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==}
-
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
-
-  '@rolldown/binding-android-arm64@1.0.0-rc.9':
-    resolution: {integrity: sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
-    resolution: {integrity: sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rolldown/binding-darwin-x64@1.0.0-rc.9':
-    resolution: {integrity: sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
-    resolution: {integrity: sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
-    resolution: {integrity: sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
-    resolution: {integrity: sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
-    resolution: {integrity: sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
-    resolution: {integrity: sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
-    resolution: {integrity: sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
-    resolution: {integrity: sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
-    resolution: {integrity: sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
-    resolution: {integrity: sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
-    resolution: {integrity: sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
-
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
-    resolution: {integrity: sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
-    resolution: {integrity: sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
-  '@rolldown/pluginutils@1.0.0-rc.9':
-    resolution: {integrity: sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==}
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -1146,9 +876,6 @@ packages:
     resolution: {integrity: sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
-
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -1549,11 +1276,6 @@ packages:
 
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
-
-  esbuild@0.27.3:
-    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   esbuild@0.27.4:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
@@ -2508,11 +2230,6 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rolldown@1.0.0-rc.9:
-    resolution: {integrity: sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -2819,49 +2536,6 @@ packages:
       less:
         optional: true
       lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
-  vite@8.0.0:
-    resolution: {integrity: sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.0.0-alpha.31
-      esbuild: ^0.27.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      '@vitejs/devtools':
-        optional: true
-      esbuild:
-        optional: true
-      jiti:
-        optional: true
-      less:
         optional: true
       sass:
         optional: true
@@ -3216,173 +2890,84 @@ snapshots:
 
   '@emmetio/stream-reader@2.2.0': {}
 
-  '@emnapi/core@1.9.0':
-    dependencies:
-      '@emnapi/wasi-threads': 1.2.0
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/runtime@1.8.1':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/wasi-threads@1.2.0':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@esbuild/aix-ppc64@0.27.3':
-    optional: true
-
   '@esbuild/aix-ppc64@0.27.4':
-    optional: true
-
-  '@esbuild/android-arm64@0.27.3':
     optional: true
 
   '@esbuild/android-arm64@0.27.4':
     optional: true
 
-  '@esbuild/android-arm@0.27.3':
-    optional: true
-
   '@esbuild/android-arm@0.27.4':
-    optional: true
-
-  '@esbuild/android-x64@0.27.3':
     optional: true
 
   '@esbuild/android-x64@0.27.4':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.3':
-    optional: true
-
   '@esbuild/darwin-arm64@0.27.4':
-    optional: true
-
-  '@esbuild/darwin-x64@0.27.3':
     optional: true
 
   '@esbuild/darwin-x64@0.27.4':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.3':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.27.4':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.27.3':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.4':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.3':
-    optional: true
-
   '@esbuild/linux-arm64@0.27.4':
-    optional: true
-
-  '@esbuild/linux-arm@0.27.3':
     optional: true
 
   '@esbuild/linux-arm@0.27.4':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.3':
-    optional: true
-
   '@esbuild/linux-ia32@0.27.4':
-    optional: true
-
-  '@esbuild/linux-loong64@0.27.3':
     optional: true
 
   '@esbuild/linux-loong64@0.27.4':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.3':
-    optional: true
-
   '@esbuild/linux-mips64el@0.27.4':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.3':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.4':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.3':
-    optional: true
-
   '@esbuild/linux-riscv64@0.27.4':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.3':
     optional: true
 
   '@esbuild/linux-s390x@0.27.4':
     optional: true
 
-  '@esbuild/linux-x64@0.27.3':
-    optional: true
-
   '@esbuild/linux-x64@0.27.4':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.4':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.3':
-    optional: true
-
   '@esbuild/netbsd-x64@0.27.4':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.4':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.3':
-    optional: true
-
   '@esbuild/openbsd-x64@0.27.4':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.3':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.4':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.3':
-    optional: true
-
   '@esbuild/sunos-x64@0.27.4':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.3':
     optional: true
 
   '@esbuild/win32-arm64@0.27.4':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.3':
-    optional: true
-
   '@esbuild/win32-ia32@0.27.4':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.3':
     optional: true
 
   '@esbuild/win32-x64@0.27.4':
@@ -3582,13 +3167,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@napi-rs/wasm-runtime@1.1.1':
-    dependencies:
-      '@emnapi/core': 1.9.0
-      '@emnapi/runtime': 1.8.1
-      '@tybys/wasm-util': 0.10.1
-    optional: true
-
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3603,60 +3181,7 @@ snapshots:
 
   '@oslojs/encoding@1.1.0': {}
 
-  '@oxc-project/runtime@0.115.0': {}
-
-  '@oxc-project/types@0.115.0': {}
-
   '@pkgr/core@0.2.9': {}
-
-  '@rolldown/binding-android-arm64@1.0.0-rc.9':
-    optional: true
-
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
-    optional: true
-
-  '@rolldown/binding-darwin-x64@1.0.0-rc.9':
-    optional: true
-
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
-    optional: true
-
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
-    optional: true
-
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
-    optional: true
-
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
-    optional: true
-
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
-    optional: true
-
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
-    optional: true
-
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
-    optional: true
-
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
-    optional: true
-
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
-    optional: true
-
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.1.1
-    optional: true
-
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
-    optional: true
-
-  '@rolldown/pluginutils@1.0.0-rc.9': {}
 
   '@rollup/pluginutils@5.3.0(rollup@4.59.0)':
     dependencies:
@@ -3847,17 +3372,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.2.1
 
-  '@tailwindcss/vite@4.2.1(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.2))':
+  '@tailwindcss/vite@4.2.1(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2))':
     dependencies:
       '@tailwindcss/node': 4.2.1
       '@tailwindcss/oxide': 4.2.1
       tailwindcss: 4.2.1
-      vite: 8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.2)
-
-  '@tybys/wasm-util@0.10.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)
 
   '@types/debug@4.1.12':
     dependencies:
@@ -4382,35 +3902,6 @@ snapshots:
       acorn: 8.16.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
-
-  esbuild@0.27.3:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.3
-      '@esbuild/android-arm': 0.27.3
-      '@esbuild/android-arm64': 0.27.3
-      '@esbuild/android-x64': 0.27.3
-      '@esbuild/darwin-arm64': 0.27.3
-      '@esbuild/darwin-x64': 0.27.3
-      '@esbuild/freebsd-arm64': 0.27.3
-      '@esbuild/freebsd-x64': 0.27.3
-      '@esbuild/linux-arm': 0.27.3
-      '@esbuild/linux-arm64': 0.27.3
-      '@esbuild/linux-ia32': 0.27.3
-      '@esbuild/linux-loong64': 0.27.3
-      '@esbuild/linux-mips64el': 0.27.3
-      '@esbuild/linux-ppc64': 0.27.3
-      '@esbuild/linux-riscv64': 0.27.3
-      '@esbuild/linux-s390x': 0.27.3
-      '@esbuild/linux-x64': 0.27.3
-      '@esbuild/netbsd-arm64': 0.27.3
-      '@esbuild/netbsd-x64': 0.27.3
-      '@esbuild/openbsd-arm64': 0.27.3
-      '@esbuild/openbsd-x64': 0.27.3
-      '@esbuild/openharmony-arm64': 0.27.3
-      '@esbuild/sunos-x64': 0.27.3
-      '@esbuild/win32-arm64': 0.27.3
-      '@esbuild/win32-ia32': 0.27.3
-      '@esbuild/win32-x64': 0.27.3
 
   esbuild@0.27.4:
     optionalDependencies:
@@ -4981,6 +4472,7 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
+    optional: true
 
   locate-path@6.0.0:
     dependencies:
@@ -5754,27 +5246,6 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown@1.0.0-rc.9:
-    dependencies:
-      '@oxc-project/types': 0.115.0
-      '@rolldown/pluginutils': 1.0.0-rc.9
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.9
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.9
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.9
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.9
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.9
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.9
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.9
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.9
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.9
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.9
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.9
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.9
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.9
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.9
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.9
-
   rollup@4.59.0:
     dependencies:
       '@types/estree': 1.0.8
@@ -6072,7 +5543,7 @@ snapshots:
 
   vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2):
     dependencies:
-      esbuild: 0.27.3
+      esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.8
@@ -6083,21 +5554,6 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
-      yaml: 2.8.2
-
-  vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(yaml@2.8.2):
-    dependencies:
-      '@oxc-project/runtime': 0.115.0
-      lightningcss: 1.32.0
-      picomatch: 4.0.3
-      postcss: 8.5.8
-      rolldown: 1.0.0-rc.9
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.12.0
-      esbuild: 0.27.4
-      fsevents: 2.3.3
-      jiti: 2.6.1
       yaml: 2.8.2
 
   vitefu@1.1.2(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.2)):

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -1,0 +1,77 @@
+---
+import type { MarkdownHeading } from "astro";
+
+type Props = {
+  headings: MarkdownHeading[];
+  variant?: "mobile" | "desktop";
+  title?: string;
+};
+
+const {
+  headings,
+  variant = "desktop",
+  title = "On this page",
+} = Astro.props;
+
+const tocHeadings = headings.filter(({ depth }) => depth >= 2 && depth <= 4);
+
+if (tocHeadings.length === 0) {
+  return null;
+}
+
+const listClass = variant === "mobile" ? "blog-toc__list blog-toc__list--mobile" : "blog-toc__list";
+const depthClasses = {
+  2: "blog-toc__link",
+  3: "blog-toc__link blog-toc__link--depth-3",
+  4: "blog-toc__link blog-toc__link--depth-4",
+} as const;
+---
+
+{variant === "mobile" ? (
+  <details class="blog-toc blog-toc--mobile animate lg:hidden">
+    <summary class="blog-toc__summary">
+      <span>{title}</span>
+      <svg
+        class="blog-toc__chevron"
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.8"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path d="m6 9 6 6 6-6"></path>
+      </svg>
+    </summary>
+    <nav class="blog-toc__body" aria-label="Table of contents">
+      <ul class={listClass}>
+        {tocHeadings.map((heading) => (
+          <li>
+            <a href={`#${heading.slug}`} class={depthClasses[heading.depth as 2 | 3 | 4]}>
+              {heading.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  </details>
+) : (
+  <aside class="blog-toc blog-toc--desktop animate hidden lg:block" aria-label="Table of contents">
+    <div class="blog-toc__title">{title}</div>
+    <nav class="blog-toc__body">
+      <ul class={listClass}>
+        {tocHeadings.map((heading) => (
+          <li>
+            <a href={`#${heading.slug}`} class={depthClasses[heading.depth as 2 | 3 | 4]}>
+              {heading.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  </aside>
+)}

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -28,7 +28,7 @@ const depthClasses = {
 ---
 
 {variant === "mobile" ? (
-  <details class="blog-toc blog-toc--mobile animate lg:hidden">
+  <details class="blog-toc blog-toc--mobile animate xl:hidden">
     <summary class="blog-toc__summary">
       <span>{title}</span>
       <svg
@@ -60,7 +60,7 @@ const depthClasses = {
     </nav>
   </details>
 ) : (
-  <aside class="blog-toc blog-toc--desktop animate hidden lg:block" aria-label="Table of contents">
+  <aside class="blog-toc blog-toc--desktop animate hidden xl:block" aria-label="Table of contents">
     <div class="blog-toc__title">{title}</div>
     <nav class="blog-toc__body">
       <ul class={listClass}>

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -10,7 +10,7 @@ type Props = {
 const {
   headings,
   variant = "desktop",
-  title = "On this page",
+  title = "Contents",
 } = Astro.props;
 
 const tocHeadings = headings.filter(({ depth }) => depth >= 2 && depth <= 4);
@@ -30,7 +30,29 @@ const depthClasses = {
 {variant === "mobile" ? (
   <details class="blog-toc blog-toc--mobile animate xl:hidden">
     <summary class="blog-toc__summary">
-      <span>{title}</span>
+      <span class="blog-toc__heading">
+        <svg
+          class="blog-toc__heading-icon"
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.8"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <line x1="8" y1="6" x2="21" y2="6"></line>
+          <line x1="8" y1="12" x2="21" y2="12"></line>
+          <line x1="8" y1="18" x2="21" y2="18"></line>
+          <circle cx="4" cy="6" r="1"></circle>
+          <circle cx="4" cy="12" r="1"></circle>
+          <circle cx="4" cy="18" r="1"></circle>
+        </svg>
+        <span>{title}</span>
+      </span>
       <svg
         class="blog-toc__chevron"
         xmlns="http://www.w3.org/2000/svg"
@@ -51,7 +73,13 @@ const depthClasses = {
       <ul class={listClass}>
         {tocHeadings.map((heading) => (
           <li>
-            <a href={`#${heading.slug}`} class={depthClasses[heading.depth as 2 | 3 | 4]}>
+            <a
+              href={`#${heading.slug}`}
+              class={depthClasses[heading.depth as 2 | 3 | 4]}
+              data-toc-link="true"
+              data-slug={heading.slug}
+              data-active="false"
+            >
               {heading.text}
             </a>
           </li>
@@ -61,12 +89,42 @@ const depthClasses = {
   </details>
 ) : (
   <aside class="blog-toc blog-toc--desktop animate hidden xl:block" aria-label="Table of contents">
-    <div class="blog-toc__title">{title}</div>
+    <div class="blog-toc__title">
+      <span class="blog-toc__heading">
+        <svg
+          class="blog-toc__heading-icon"
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.8"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <line x1="8" y1="6" x2="21" y2="6"></line>
+          <line x1="8" y1="12" x2="21" y2="12"></line>
+          <line x1="8" y1="18" x2="21" y2="18"></line>
+          <circle cx="4" cy="6" r="1"></circle>
+          <circle cx="4" cy="12" r="1"></circle>
+          <circle cx="4" cy="18" r="1"></circle>
+        </svg>
+        <span>{title}</span>
+      </span>
+    </div>
     <nav class="blog-toc__body">
       <ul class={listClass}>
         {tocHeadings.map((heading) => (
           <li>
-            <a href={`#${heading.slug}`} class={depthClasses[heading.depth as 2 | 3 | 4]}>
+            <a
+              href={`#${heading.slug}`}
+              class={depthClasses[heading.depth as 2 | 3 | 4]}
+              data-toc-link="true"
+              data-slug={heading.slug}
+              data-active="false"
+            >
               {heading.text}
             </a>
           </li>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -227,8 +227,120 @@ const hasToc = tocHeadings.length > 0;
       });
     };
 
+    const syncTableOfContents = () => {
+      window.__blogTocCleanup?.();
+
+      const article = document.querySelector(".blog-article");
+      if (!article) return;
+
+      const headings = Array.from(article.querySelectorAll("h2[id], h3[id], h4[id]"));
+      const tocLinks = Array.from(document.querySelectorAll("[data-toc-link='true']"));
+      if (headings.length === 0 || tocLinks.length === 0) {
+        return;
+      }
+
+      let activeSlug = "";
+      let frameId = 0;
+      let observer;
+
+      const setActiveSlug = (slug) => {
+        if (slug === activeSlug) return;
+        activeSlug = slug;
+
+        tocLinks.forEach((link) => {
+          if (!(link instanceof HTMLElement)) return;
+          link.setAttribute("data-active", link.dataset.slug === slug ? "true" : "false");
+        });
+      };
+
+      const getActiveSlugFromViewport = () => {
+        const activationOffset = 140;
+        let candidate = null;
+
+        for (const heading of headings) {
+          const top = heading.getBoundingClientRect().top;
+          if (top - activationOffset <= 0) {
+            candidate = heading;
+            continue;
+          }
+
+          if (!candidate && top <= window.innerHeight * 0.6) {
+            candidate = heading;
+          }
+          break;
+        }
+
+        if (!candidate) {
+          return headings[0]?.id ?? "";
+        }
+
+        return candidate.id;
+      };
+
+      const setActiveSlugFromHash = () => {
+        const hashSlug = decodeURIComponent(window.location.hash.replace(/^#/, ""));
+        if (!hashSlug) return false;
+
+        const hashedHeading = headings.find((heading) => heading.id === hashSlug);
+        if (!hashedHeading) return false;
+
+        setActiveSlug(hashedHeading.id);
+        return true;
+      };
+
+      const updateActiveHeading = () => {
+        frameId = 0;
+        setActiveSlug(getActiveSlugFromViewport());
+      };
+
+      const handleHashChange = () => {
+        if (setActiveSlugFromHash()) {
+          window.setTimeout(() => {
+            requestUpdate();
+          }, 80);
+        }
+      };
+
+      const requestUpdate = () => {
+        if (frameId) return;
+        frameId = window.requestAnimationFrame(updateActiveHeading);
+      };
+
+      observer = new IntersectionObserver(
+        () => {
+          requestUpdate();
+        },
+        {
+          rootMargin: "-15% 0px -55% 0px",
+          threshold: [0, 1],
+        }
+      );
+
+      headings.forEach((heading) => observer.observe(heading));
+      window.addEventListener("hashchange", handleHashChange);
+      window.addEventListener("resize", requestUpdate);
+      window.addEventListener("scroll", requestUpdate, { passive: true });
+
+      if (!setActiveSlugFromHash()) {
+        requestUpdate();
+      }
+
+      window.__blogTocCleanup = () => {
+        if (frameId) {
+          window.cancelAnimationFrame(frameId);
+          frameId = 0;
+        }
+        observer?.disconnect();
+        window.removeEventListener("hashchange", handleHashChange);
+        window.removeEventListener("resize", requestUpdate);
+        window.removeEventListener("scroll", requestUpdate);
+      };
+    };
+
     bindGlobalLightboxClose();
     document.addEventListener("DOMContentLoaded", setupImageLightbox);
     document.addEventListener("astro:page-load", setupImageLightbox);
+    document.addEventListener("DOMContentLoaded", syncTableOfContents);
+    document.addEventListener("astro:page-load", syncTableOfContents);
   </script>
 </PageLayout>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -32,17 +32,13 @@ type Props = {
 const { post, prev, next } = Astro.props;
 const { Content, headings } = await render(post);
 const postBody = post.body ?? "";
-const hasToc = headings.some((heading) => heading.depth >= 2 && heading.depth <= 4);
+const tocHeadings = headings.filter((heading) => heading.depth >= 2 && heading.depth <= 4);
+const hasToc = tocHeadings.length > 0;
 ---
 
 <PageLayout title={`${post.data.title} | ${SITE.NAME}`} description={post.data.description}>
-  <div class="mx-auto max-w-screen-xl px-5">
-    <div
-      class:list={[
-        "blog-post-layout",
-        hasToc && "blog-post-layout--with-toc",
-      ]}
-    >
+  <div class="px-5">
+    <div class="blog-post-shell">
       <div class="blog-post-main">
         <div class="space-y-2 my-6">
           <div class="animate text-xl sm:text-2xl font-semibold text-black/75 dark:text-white">
@@ -81,7 +77,7 @@ const hasToc = headings.some((heading) => heading.depth >= 2 && heading.depth <=
           </div>
         </div>
 
-        {hasToc && <TableOfContents headings={headings} variant="mobile" />}
+        {hasToc && <TableOfContents headings={tocHeadings} variant="mobile" />}
 
         <article class="animate mt-10 blog-article">
           <Content />
@@ -120,7 +116,11 @@ const hasToc = headings.some((heading) => heading.depth >= 2 && heading.depth <=
         )}
       </div>
 
-      {hasToc && <TableOfContents headings={headings} />}
+      {hasToc && (
+        <div class="blog-post-toc-rail">
+          <TableOfContents headings={tocHeadings} />
+        </div>
+      )}
     </div>
   </div>
 

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,9 +1,9 @@
 ---
 import { type CollectionEntry, getCollection, render } from "astro:content";
 import PageLayout from "@layouts/PageLayout.astro";
-import Container from "@components/Container.astro";
 import FormattedDate from "@components/FormattedDate.astro";
 import LinkEnhancer from "@components/LinkEnhancer.astro";
+import TableOfContents from "@components/TableOfContents.astro";
 import { readingTime, wordCount } from "@lib/utils";
 import { SITE } from "@consts";
 
@@ -30,85 +30,99 @@ type Props = {
 };
 
 const { post, prev, next } = Astro.props;
-const { Content } = await render(post);
+const { Content, headings } = await render(post);
 const postBody = post.body ?? "";
+const hasToc = headings.some((heading) => heading.depth >= 2 && heading.depth <= 4);
 ---
 
 <PageLayout title={`${post.data.title} | ${SITE.NAME}`} description={post.data.description}>
-  <Container>
-    <div class="space-y-2 my-6">
-      <div class="animate text-xl sm:text-2xl font-semibold text-black/75 dark:text-white">
-        {post.data.title}
+  <div class="mx-auto max-w-screen-xl px-5">
+    <div
+      class:list={[
+        "blog-post-layout",
+        hasToc && "blog-post-layout--with-toc",
+      ]}
+    >
+      <div class="blog-post-main">
+        <div class="space-y-2 my-6">
+          <div class="animate text-xl sm:text-2xl font-semibold text-black/75 dark:text-white">
+            {post.data.title}
+          </div>
+
+          <div class="animate flex flex-wrap items-center gap-x-3 gap-y-1 text-sm bg-stone-100 dark:bg-stone-900 text-black/75 dark:text-white/80 py-1 px-2 rounded">
+            <div class="flex items-center gap-1 whitespace-nowrap">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
+                <line x1="16" y1="2" x2="16" y2="6"></line>
+                <line x1="8" y1="2" x2="8" y2="6"></line>
+                <line x1="3" y1="10" x2="21" y2="10"></line>
+              </svg>
+              <FormattedDate date={post.data.date} />
+            </div>
+            <div class="flex items-center gap-1 whitespace-nowrap">
+              <span class="text-black/35 dark:text-white/35" aria-hidden="true">·</span>
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                <polyline points="14 2 14 8 20 8"></polyline>
+                <line x1="16" y1="13" x2="8" y2="13"></line>
+                <line x1="16" y1="17" x2="8" y2="17"></line>
+                <line x1="10" y1="9" x2="8" y2="9"></line>
+              </svg>
+              <span>{wordCount(postBody)}</span>
+            </div>
+            <div class="flex items-center gap-1 whitespace-nowrap">
+              <span class="text-black/35 dark:text-white/35" aria-hidden="true">·</span>
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="10"></circle>
+                <polyline points="12 6 12 12 16 14"></polyline>
+              </svg>
+              <span>{readingTime(postBody)}</span>
+            </div>
+          </div>
+        </div>
+
+        {hasToc && <TableOfContents headings={headings} variant="mobile" />}
+
+        <article class="animate mt-10 blog-article">
+          <Content />
+        </article>
+
+        {(prev || next) && (
+          <>
+            <hr class="animate mt-4 mb-4 border-black/10 dark:border-white/10" />
+            <div class="animate mt-4 mb-6 flex flex-col gap-2 sm:flex-row sm:justify-between">
+              {prev ? (
+                <a href={`/blog/${prev.id}`} class="group flex w-full items-center gap-1 px-4 py-2 rounded-lg transition-colors duration-300">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="group-hover:-translate-x-1 transition-transform duration-300">
+                    <path d="m15 18-6-6 6-6"/>
+                  </svg>
+                  <div class="min-w-0">
+                    <div class="text-sm max-w-full break-words sm:max-w-[300px] sm:truncate">{prev.data.title}</div>
+                  </div>
+                </a>
+              ) : (
+                <div class="hidden sm:block"></div>
+              )}
+              {next ? (
+                <a href={`/blog/${next.id}`} class="group flex w-full items-center justify-between gap-1 px-4 py-2 rounded-lg transition-colors duration-300 sm:w-auto sm:justify-end">
+                  <div class="text-left sm:text-right">
+                    <div class="text-sm max-w-full break-words sm:max-w-[300px] sm:truncate">{next.data.title}</div>
+                  </div>
+                  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="group-hover:translate-x-1 transition-transform duration-300">
+                    <path d="m9 18 6-6-6-6"/>
+                  </svg>
+                </a>
+              ) : (
+                <div class="hidden sm:block"></div>
+              )}
+            </div>
+          </>
+        )}
       </div>
 
-      <div class="animate flex flex-wrap items-center gap-x-3 gap-y-1 text-sm bg-stone-100 dark:bg-stone-900 text-black/75 dark:text-white/80 py-1 px-2 rounded">
-        <div class="flex items-center gap-1 whitespace-nowrap">
-          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
-            <line x1="16" y1="2" x2="16" y2="6"></line>
-            <line x1="8" y1="2" x2="8" y2="6"></line>
-            <line x1="3" y1="10" x2="21" y2="10"></line>
-          </svg>
-          <FormattedDate date={post.data.date} />
-        </div>
-        <div class="flex items-center gap-1 whitespace-nowrap">
-          <span class="text-black/35 dark:text-white/35" aria-hidden="true">·</span>
-          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
-            <polyline points="14 2 14 8 20 8"></polyline>
-            <line x1="16" y1="13" x2="8" y2="13"></line>
-            <line x1="16" y1="17" x2="8" y2="17"></line>
-            <line x1="10" y1="9" x2="8" y2="9"></line>
-          </svg>
-          <span>{wordCount(postBody)}</span>
-        </div>
-        <div class="flex items-center gap-1 whitespace-nowrap">
-          <span class="text-black/35 dark:text-white/35" aria-hidden="true">·</span>
-          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="12" cy="12" r="10"></circle>
-            <polyline points="12 6 12 12 16 14"></polyline>
-          </svg>
-          <span>{readingTime(postBody)}</span>
-        </div>
-      </div>
+      {hasToc && <TableOfContents headings={headings} />}
     </div>
-
-    <article class="animate mt-10 blog-article">
-      <Content />
-    </article>
-
-    {(prev || next) && (
-      <>
-        <hr class="animate mt-4 mb-4 border-black/10 dark:border-white/10" />
-        <div class="animate mt-4 mb-6 flex flex-col gap-2 sm:flex-row sm:justify-between">
-          {prev ? (
-            <a href={`/blog/${prev.id}`} class="group flex w-full items-center gap-1 px-4 py-2 rounded-lg transition-colors duration-300">
-              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="group-hover:-translate-x-1 transition-transform duration-300">
-                <path d="m15 18-6-6 6-6"/>
-              </svg>
-              <div class="min-w-0">
-                <div class="text-sm max-w-full break-words sm:max-w-[300px] sm:truncate">{prev.data.title}</div>
-              </div>
-            </a>
-          ) : (
-            <div class="hidden sm:block"></div>
-          )}
-          {next ? (
-            <a href={`/blog/${next.id}`} class="group flex w-full items-center justify-between gap-1 px-4 py-2 rounded-lg transition-colors duration-300 sm:w-auto sm:justify-end">
-              <div class="text-left sm:text-right">
-                <div class="text-sm max-w-full break-words sm:max-w-[300px] sm:truncate">{next.data.title}</div>
-              </div>
-              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="group-hover:translate-x-1 transition-transform duration-300">
-                <path d="m9 18 6-6-6-6"/>
-              </svg>
-            </a>
-          ) : (
-            <div class="hidden sm:block"></div>
-          )}
-        </div>
-      </>
-    )}
-  </Container>
+  </div>
 
   <LinkEnhancer />
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -470,11 +470,11 @@ figcaption {
 }
 
 .blog-toc__link--depth-3 {
-  @apply pl-4 text-[0.78rem];
+  @apply pl-6 text-[0.78rem];
 }
 
 .blog-toc__link--depth-4 {
-  @apply pl-6 text-[0.76rem];
+  @apply pl-9 text-[0.76rem];
 }
 
 @media (min-width: 640px) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -395,9 +395,9 @@ figcaption {
 }
 
 .blog-toc {
-  @apply rounded-xl border border-black/8 bg-white/45 text-sm text-black/55;
-  @apply dark:border-white/8 dark:bg-white/[0.025] dark:text-white/55;
-  @apply backdrop-blur-sm;
+  @apply rounded-xl border border-black/6 bg-white/28 text-sm text-black/46;
+  @apply dark:border-white/6 dark:bg-white/[0.015] dark:text-white/42;
+  @apply backdrop-blur-[2px];
 }
 
 .blog-toc--mobile {
@@ -410,7 +410,7 @@ figcaption {
 
 .blog-toc__summary,
 .blog-toc__title {
-  @apply flex items-center justify-between gap-3 font-medium text-black/72 dark:text-white/72;
+  @apply flex items-center justify-between gap-3 text-black/56 dark:text-white/52;
 }
 
 .blog-toc__summary {
@@ -418,15 +418,23 @@ figcaption {
 }
 
 .blog-toc__title {
-  @apply px-2 text-[0.72rem] uppercase tracking-[0.18em];
+  @apply px-2 pb-2 text-[0.82rem];
 }
 
 .blog-toc__summary::-webkit-details-marker {
   display: none;
 }
 
+.blog-toc__heading {
+  @apply inline-flex items-center gap-2 font-medium;
+}
+
+.blog-toc__heading-icon {
+  @apply shrink-0 opacity-60;
+}
+
 .blog-toc__chevron {
-  @apply shrink-0 transition-transform duration-200 ease-out;
+  @apply shrink-0 opacity-55 transition-transform duration-200 ease-out;
 }
 
 .blog-toc--mobile[open] .blog-toc__chevron {
@@ -434,7 +442,7 @@ figcaption {
 }
 
 .blog-toc__body {
-  @apply px-2 pb-1.5;
+  @apply px-2 pb-1.5 pt-0.5;
 }
 
 .blog-toc__list {
@@ -442,13 +450,23 @@ figcaption {
 }
 
 .blog-toc__list--mobile {
-  @apply px-2 pb-1.5 pt-0.5;
+  @apply px-2 pb-1 pt-0.75;
 }
 
 .blog-toc__link {
-  @apply block rounded-md px-2 py-0.75 text-[0.8rem] leading-snug text-black/52 transition-colors duration-200;
-  @apply hover:bg-black/[0.035] hover:text-black/78 dark:text-white/52 dark:hover:bg-white/[0.04] dark:hover:text-white/78;
+  @apply block rounded-md border-l border-transparent px-2 py-0.75 text-[0.8rem] leading-snug text-black/42 transition-colors duration-200;
+  @apply hover:bg-black/[0.02] hover:text-black/58 dark:text-white/40 dark:hover:bg-white/[0.025] dark:hover:text-white/60;
   overflow-wrap: anywhere;
+}
+
+.blog-toc__link[data-active="true"] {
+  @apply border-black/20 bg-black/[0.035] font-medium text-black/80;
+  @apply dark:border-white/20 dark:bg-white/[0.04] dark:text-white/82;
+}
+
+.blog-toc__link:focus-visible {
+  @apply border-black/22 bg-black/[0.025] text-black/70 outline-none;
+  @apply dark:border-white/22 dark:bg-white/[0.03] dark:text-white/72;
 }
 
 .blog-toc__link--depth-3 {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -46,7 +46,7 @@ footer {
 }
 
 .blog-post-toc-rail {
-  @apply hidden xl:block absolute left-full top-0 ml-10 w-48;
+  @apply hidden xl:block absolute left-full top-1/2 ml-24 w-48 -translate-y-1/2;
 }
 
 article {
@@ -404,7 +404,7 @@ figcaption {
 }
 
 .blog-toc--desktop {
-  @apply sticky top-24 max-h-[calc(100vh-7rem)] overflow-auto px-3 py-3;
+  @apply max-h-[calc(100vh-8rem)] overflow-auto px-3 py-3;
 }
 
 .blog-toc__summary,
@@ -433,19 +433,19 @@ figcaption {
 }
 
 .blog-toc__body {
-  @apply px-2 pb-2;
+  @apply px-2 pb-1.5;
 }
 
 .blog-toc__list {
-  @apply flex flex-col gap-1;
+  @apply flex flex-col gap-0.5;
 }
 
 .blog-toc__list--mobile {
-  @apply px-2 pb-2 pt-1;
+  @apply px-2 pb-1.5 pt-0.5;
 }
 
 .blog-toc__link {
-  @apply block rounded-md px-2 py-1 text-[0.8rem] leading-relaxed text-black/52 transition-colors duration-200;
+  @apply block rounded-md px-2 py-0.75 text-[0.8rem] leading-snug text-black/52 transition-colors duration-200;
   @apply hover:bg-black/[0.035] hover:text-black/78 dark:text-white/52 dark:hover:bg-white/[0.04] dark:hover:text-white/78;
   overflow-wrap: anywhere;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -37,6 +37,18 @@ footer {
   @apply py-5 text-sm;
 }
 
+.blog-post-layout {
+  @apply flex flex-col gap-8;
+}
+
+.blog-post-layout--with-toc {
+  @apply lg:grid lg:grid-cols-[minmax(0,1fr)_17rem] lg:items-start lg:gap-10;
+}
+
+.blog-post-main {
+  @apply min-w-0 w-full max-w-screen-md;
+}
+
 article {
   @apply max-w-full prose dark:prose-invert prose-img:mx-auto prose-img:my-auto;
   @apply prose-headings:font-semibold prose-p:font-serif;
@@ -254,6 +266,10 @@ html.image-lightbox-open {
   overflow: hidden;
 }
 
+.blog-article :is(h2, h3, h4) {
+  scroll-margin-top: 6.5rem;
+}
+
 .blog-article img {
   cursor: zoom-in;
   transition: transform 160ms ease, box-shadow 160ms ease;
@@ -375,4 +391,71 @@ figcaption {
 
 .prose img, .prose-invert img, article img {
   @apply !rounded-lg !shadow-sm;
+}
+
+.blog-toc {
+  @apply rounded-2xl border border-black/10 bg-white/65 text-sm text-black/70 shadow-sm;
+  @apply dark:border-white/10 dark:bg-white/[0.04] dark:text-white/70;
+  @apply backdrop-blur-sm;
+}
+
+.blog-toc--mobile {
+  @apply mt-8 overflow-hidden;
+}
+
+.blog-toc--desktop {
+  @apply sticky top-24 max-h-[calc(100vh-7rem)] overflow-auto p-4;
+}
+
+.blog-toc__summary,
+.blog-toc__title {
+  @apply flex items-center justify-between gap-3 font-semibold text-black/80 dark:text-white/85;
+}
+
+.blog-toc__summary {
+  @apply cursor-pointer list-none p-4;
+}
+
+.blog-toc__summary::-webkit-details-marker {
+  display: none;
+}
+
+.blog-toc__chevron {
+  @apply shrink-0 transition-transform duration-200 ease-out;
+}
+
+.blog-toc--mobile[open] .blog-toc__chevron {
+  transform: rotate(180deg);
+}
+
+.blog-toc__body {
+  @apply px-4 pb-4;
+}
+
+.blog-toc__list {
+  @apply flex flex-col gap-1.5;
+}
+
+.blog-toc__list--mobile {
+  @apply pt-1;
+}
+
+.blog-toc__link {
+  @apply block rounded-md px-2 py-1.5 text-sm leading-relaxed text-black/65 transition-colors duration-200;
+  @apply hover:bg-black/[0.04] hover:text-black/90 dark:text-white/65 dark:hover:bg-white/[0.05] dark:hover:text-white/90;
+  overflow-wrap: anywhere;
+}
+
+.blog-toc__link--depth-3 {
+  @apply pl-5 text-[0.92rem];
+}
+
+.blog-toc__link--depth-4 {
+  @apply pl-8 text-[0.9rem];
+}
+
+@media (min-width: 640px) {
+  .blog-article :is(h2, h3, h4) {
+    scroll-margin-top: 7rem;
+  }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -46,7 +46,8 @@ footer {
 }
 
 .blog-post-toc-rail {
-  @apply hidden xl:block absolute left-full top-1/2 ml-24 w-48 -translate-y-1/2;
+  @apply hidden xl:block fixed top-1/2 w-48 -translate-y-1/2;
+  left: min(calc(50% + 29rem), calc(100vw - 14rem));
 }
 
 article {
@@ -404,7 +405,7 @@ figcaption {
 }
 
 .blog-toc--desktop {
-  @apply max-h-[calc(100vh-8rem)] overflow-auto px-3 py-3;
+  @apply max-h-[calc(100vh-7rem)] overflow-auto px-3 py-3;
 }
 
 .blog-toc__summary,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -37,16 +37,16 @@ footer {
   @apply py-5 text-sm;
 }
 
-.blog-post-layout {
-  @apply flex flex-col gap-8;
-}
-
-.blog-post-layout--with-toc {
-  @apply lg:grid lg:grid-cols-[minmax(0,1fr)_17rem] lg:items-start lg:gap-10;
+.blog-post-shell {
+  @apply relative mx-auto max-w-screen-md;
 }
 
 .blog-post-main {
-  @apply min-w-0 w-full max-w-screen-md;
+  @apply min-w-0 w-full;
+}
+
+.blog-post-toc-rail {
+  @apply hidden xl:block absolute left-full top-0 ml-10 w-48;
 }
 
 article {
@@ -394,8 +394,8 @@ figcaption {
 }
 
 .blog-toc {
-  @apply rounded-2xl border border-black/10 bg-white/65 text-sm text-black/70 shadow-sm;
-  @apply dark:border-white/10 dark:bg-white/[0.04] dark:text-white/70;
+  @apply rounded-xl border border-black/8 bg-white/45 text-sm text-black/55;
+  @apply dark:border-white/8 dark:bg-white/[0.025] dark:text-white/55;
   @apply backdrop-blur-sm;
 }
 
@@ -404,16 +404,20 @@ figcaption {
 }
 
 .blog-toc--desktop {
-  @apply sticky top-24 max-h-[calc(100vh-7rem)] overflow-auto p-4;
+  @apply sticky top-24 max-h-[calc(100vh-7rem)] overflow-auto px-3 py-3;
 }
 
 .blog-toc__summary,
 .blog-toc__title {
-  @apply flex items-center justify-between gap-3 font-semibold text-black/80 dark:text-white/85;
+  @apply flex items-center justify-between gap-3 font-medium text-black/72 dark:text-white/72;
 }
 
 .blog-toc__summary {
   @apply cursor-pointer list-none p-4;
+}
+
+.blog-toc__title {
+  @apply px-2 text-[0.72rem] uppercase tracking-[0.18em];
 }
 
 .blog-toc__summary::-webkit-details-marker {
@@ -429,29 +433,29 @@ figcaption {
 }
 
 .blog-toc__body {
-  @apply px-4 pb-4;
+  @apply px-2 pb-2;
 }
 
 .blog-toc__list {
-  @apply flex flex-col gap-1.5;
+  @apply flex flex-col gap-1;
 }
 
 .blog-toc__list--mobile {
-  @apply pt-1;
+  @apply px-2 pb-2 pt-1;
 }
 
 .blog-toc__link {
-  @apply block rounded-md px-2 py-1.5 text-sm leading-relaxed text-black/65 transition-colors duration-200;
-  @apply hover:bg-black/[0.04] hover:text-black/90 dark:text-white/65 dark:hover:bg-white/[0.05] dark:hover:text-white/90;
+  @apply block rounded-md px-2 py-1 text-[0.8rem] leading-relaxed text-black/52 transition-colors duration-200;
+  @apply hover:bg-black/[0.035] hover:text-black/78 dark:text-white/52 dark:hover:bg-white/[0.04] dark:hover:text-white/78;
   overflow-wrap: anywhere;
 }
 
 .blog-toc__link--depth-3 {
-  @apply pl-5 text-[0.92rem];
+  @apply pl-4 text-[0.78rem];
 }
 
 .blog-toc__link--depth-4 {
-  @apply pl-8 text-[0.9rem];
+  @apply pl-6 text-[0.76rem];
 }
 
 @media (min-width: 640px) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,20 @@
     "strictNullChecks": true,
     "baseUrl": ".",
     "paths": {
-      "@*": [
-        "./src/*"
+      "@components/*": [
+        "./src/components/*"
+      ],
+      "@layouts/*": [
+        "./src/layouts/*"
+      ],
+      "@lib/*": [
+        "./src/lib/*"
+      ],
+      "@consts": [
+        "./src/consts.ts"
+      ],
+      "@types": [
+        "./src/types.ts"
       ]
     },
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary
- add a responsive table of contents for blog posts
- keep article content centered and render the desktop TOC on the right side
- render a collapsible TOC above the article on smaller screens
- only show the TOC for posts that contain H2/H3/H4 headings

## Validation
- [x] `pnpm lint`
- [x] `pnpm build`